### PR TITLE
fix: prevent duplicate mqtt connections

### DIFF
--- a/cmd/chirpstack-gateway-bridge/cmd/root.go
+++ b/cmd/chirpstack-gateway-bridge/cmd/root.go
@@ -63,7 +63,7 @@ func init() {
 	viper.SetDefault("integration.mqtt.state_retained", true)
 	viper.SetDefault("integration.mqtt.keep_alive", 30*time.Second)
 	viper.SetDefault("integration.mqtt.max_reconnect_interval", time.Minute)
-	viper.SetDefault("integration.mqtt.max_token_wait", 5*time.Second)
+	viper.SetDefault("integration.mqtt.max_token_wait", time.Minute)
 
 	viper.SetDefault("integration.mqtt.auth.generic.servers", []string{"tcp://127.0.0.1:1883"})
 	viper.SetDefault("integration.mqtt.auth.generic.clean_session", true)

--- a/internal/integration/mqtt/backend.go
+++ b/internal/integration/mqtt/backend.go
@@ -383,6 +383,9 @@ func (b *Backend) connect() error {
 		return errors.Wrap(err, "integration/mqtt: update authentication error")
 	}
 
+	if b.conn != nil {
+		b.conn.Disconnect(250)
+	}
 	b.conn = paho.NewClient(b.clientOpts)
 	if err := tokenWrapper(b.conn.Connect(), b.maxTokenWait); err != nil {
 		return err


### PR DESCRIPTION
This change is to fix issue https://github.com/chirpstack/chirpstack-gateway-bridge/issues/226.

Since the chirpstack connection timeout is shorter than the Paho one it can retry a connection while Paho is still attempting the first one. If both eventually succeed they can fight over the connection causing a constant disconnect/reconnect loop. This change increases the default chirpstack connection timeout and disconnects before it attempts a retry to prevent multiple connections from being made.
