### PR TITLE
Fix fractional part of gwTime in case of uplink received via LoRa Basics Station

### DIFF
--- a/internal/backend/basicstation/structs/radio_meta_data.go
+++ b/internal/backend/basicstation/structs/radio_meta_data.go
@@ -80,7 +80,7 @@ func SetRadioMetaDataToProto(loraBand band.Band, gatewayID lorawan.EUI64, rmd Ra
 	if rxTime := rmd.UpInfo.RxTime; rxTime != 0 {
 		sec, nsec := math.Modf(rmd.UpInfo.RxTime)
 		if sec != 0 {
-			val := time.Unix(int64(sec), int64(nsec))
+			val := time.Unix(int64(sec), int64(nsec*1e9))
 			pb.RxInfo.GwTime = timestamppb.New(val)
 		}
 	}


### PR DESCRIPTION
Whenever an uplink is received via a LoRa Basics Station gateway which doesn't gave GPS time available, the fractional second of the receive time is missing in the reported `gwTime` of the `rx_info` element.
Example:
<img width="421" alt="image" src="https://github.com/chirpstack/chirpstack-gateway-bridge/assets/2046752/3aa27306-841a-4a76-8d25-f000f9d6b617">

It seems the fractional part of the `rxtime` (as float) is not properly scaled to nanoseconds before it is cast to `int64`.

https://github.com/chirpstack/chirpstack-gateway-bridge/blob/6897fe56c2b8e631632fe2ed37e4d6dbd903f563/internal/backend/basicstation/structs/radio_meta_data.go#L80-L86

This PR fixes that. 

Note: `rxtime` in Basics Station is the radio receive time (`xtime`) converted into UTC. This conversion is susceptible to UTC synchronization issues (e.g. NTP not functioning correctly, or large/asymmetric network latencies in case of LNS-based timesync) and therefore must be used with care by any consumer. 