### PR TITLE
TLS Support by Reverse-Proxy for Basicstation

### DIFF
--- a/cmd/chirpstack-gateway-bridge/cmd/configfile.go
+++ b/cmd/chirpstack-gateway-bridge/cmd/configfile.go
@@ -111,6 +111,12 @@ type="{{ .Backend.Type }}"
   # ip:port to bind the Websocket listener to.
   bind="{{ .Backend.BasicStation.Bind }}"
 
+  # TLS support.
+  #
+  # When set to true, the websocket listener will use TLS to secure the connections
+  # between the gateways and ChirpStack Gateway Bridge.
+  tls_support={{ .Backend.BasicStation.TLSSupport }}
+
   # TLS certificate and key files.
   #
   # When set, the websocket listener will use TLS to secure the connections

--- a/cmd/chirpstack-gateway-bridge/cmd/configfile.go
+++ b/cmd/chirpstack-gateway-bridge/cmd/configfile.go
@@ -111,11 +111,11 @@ type="{{ .Backend.Type }}"
   # ip:port to bind the Websocket listener to.
   bind="{{ .Backend.BasicStation.Bind }}"
 
-  # TLS support.
+  # TLS support by a Reverse-Proxy
   #
   # When set to true, the websocket listener will use TLS to secure the connections
-  # between the gateways and ChirpStack Gateway Bridge.
-  tls_support={{ .Backend.BasicStation.TLSSupport }}
+  # between the gateways and a reverse-proxy (optional).
+  tls_support_proxy={{ .Backend.BasicStation.TLSSupportProxy }}
 
   # TLS certificate and key files.
   #

--- a/internal/backend/basicstation/backend.go
+++ b/internal/backend/basicstation/backend.go
@@ -271,7 +271,7 @@ func (b *Backend) Start() error {
 			"tls_key":  b.tlsKey,
 		}).Info("backend/basicstation: starting websocket listener")
 
-		if !b.tlsSupport { // b.tlsCert == "" && b.tlsKey == "" && b.caCert == ""
+		if !b.tlsSupport {
 			// no tls
 			if err := b.server.Serve(b.ln); err != nil && !b.isClosed {
 				log.WithError(err).Fatal("backend/basicstation: server error")
@@ -279,8 +279,11 @@ func (b *Backend) Start() error {
 		} else {
 			// tls
 			b.scheme = "wss"
-			if b.tlsCert == "" && b.tlsKey == "" && b.caCert == "" {
-				log.Warn("backend/basicstation: TLS is enabled, but no certificate or CA certificate configured.")
+			if b.tlsCert == "" && b.tlsKey == "" {
+				log.Warn("backend/basicstation: TLS is enabled, but no certificate and key configured. TLS will not be used.")
+				if err := b.server.Serve(b.ln); err != nil && !b.isClosed {
+					log.WithError(err).Fatal("backend/basicstation: server error")
+				}
 			} else {
 				if err := b.server.ServeTLS(b.ln, b.tlsCert, b.tlsKey); err != nil && !b.isClosed {
 					log.WithError(err).Fatal("backend/basicstation: server error")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,7 @@ type Config struct {
 
 		BasicStation struct {
 			Bind             string                     `mapstructure:"bind"`
-			TLSSupport       bool                       `mapstructure:"tls_support"`
+			TLSSupportProxy  bool                       `mapstructure:"tls_support_proxy"`
 			TLSCert          string                     `mapstructure:"tls_cert"`
 			TLSKey           string                     `mapstructure:"tls_key"`
 			CACert           string                     `mapstructure:"ca_cert"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 
 		BasicStation struct {
 			Bind             string                     `mapstructure:"bind"`
+			TLSSupport       bool                       `mapstructure:"tls_support"`
 			TLSCert          string                     `mapstructure:"tls_cert"`
 			TLSKey           string                     `mapstructure:"tls_key"`
 			CACert           string                     `mapstructure:"ca_cert"`


### PR DESCRIPTION
Based on the feature request #240, I implemented a way of handling a TLS Server Authentication when using a reverse-proxy like traefik or nginx.

I've made sure that this feature doesn't cause any compatibility problems with previous versions. This means that if TLS certificates are referenced, TLS will be enabled by default on the gateway-bridge, as it used to be.