### PR TITLE
Fix missing 's' in semtech backend prometheus metrics

### DIFF
--- a/internal/backend/semtechudp/metrics.go
+++ b/internal/backend/semtechudp/metrics.go
@@ -23,7 +23,7 @@ var (
 	})
 
 	gwd = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "backend_semtechudp_gateway_diconnect_count",
+		Name: "backend_semtechudp_gateway_disconnect_count",
 		Help: "The number of gateways that disconnected from the backend.",
 	})
 


### PR DESCRIPTION
add 's' to backend_semtechudp_gateway_diconnect_count metric